### PR TITLE
patch package.json types

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "indexeddb-orm",
   "version": "4.0.0-alpha.3",
   "main": "./dist/index.js",
-  "types": "./src/index.d.ts",
+  "types": "./dist/index.d.ts",
   "scripts": {
     "build": "rimraf dist && tsc -p tsconfig.build.json",
     "format": "prettier --write \"src/**/*.ts\"",


### PR DESCRIPTION
**ORM version:**  (check one with "x")
```
[ ] 1.x
[ ] 2.x
[x] 4.x

```

**What kind of change does this PR introduce?** (check one with "x")
```
[ x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**Tell about your platform if it fixes a bug**
* Operating System : Linux
* Browser and version: NA

**What is the current behavior?** (You can also link to an open issue here)
Typescript types don't work when added as a dependency as it points to `src/index.d.ts` instead of `dist/index.d.ts`


**What is the new behavior?**
Patches the issue by fixing `package.json` types key.

Also, until this is fiexed you can patch this issue by exporting the types directly:
```typescript
//modules.d.ts
declare module 'indexeddb-orm' {
    export * from 'indexeddb-orm/dist/index';
}
```